### PR TITLE
Remove libply workaround

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -10,6 +10,3 @@
 # Autobuild::Package['rtt'].prefix='/opt/autoproj/2.0'
 #
 # See config.yml to set the prefix:/opt/autoproj/2.0 globally for all packages.
-
-Autobuild::Package['external/libply'].env_set "CXX", "g++-5"
-Autobuild::Package['external/libply'].env_set "CC", "gcc-5"


### PR DESCRIPTION
This workaround is not needed anymore since the issue in libply was fixed a few days ago: https://github.com/rock-slam/external-libply/pull/5

In addition, this workaround prevented compilation as it sets the compiler to gcc-5 for all packages which does not have c++11 enabled by default. The global cxx11 option was recently removed in Rock under the assumption that newer compiler versions provide c++11 compilation by default: https://github.com/rock-core/package_set/pull/159

@levingerdes For some strange reason, this problem did not appear with your rock-docker container (set to 18.04). But it appears when bootstrapping manually on Ubuntu 18.04.
